### PR TITLE
chore(gitignore): add .serena and demo directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ examples/*/package-lock.json
 .cache/
 .eslintcache
 .prettierCache
+
+# Project-specific directories
+.serena/
+demo/


### PR DESCRIPTION
## Summary
- Add `.serena/` and `demo/` directories to .gitignore
- These are project-specific directories that should not be tracked in git

## Details
- `.serena/`: MCP server configuration directory
- `demo/`: Demo files directory

🤖 Generated with [Claude Code](https://claude.ai/code)