### PR TITLE
fix(parser): enable shebang support for Node.js scripts

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,6 +26,7 @@ export class Parser {
       ecmaVersion: 2022, // TODO: Support ES2023+ features
       sourceType: 'module',
       locations: true,
+      allowHashBang: true, // Enable shebang support by default
       ...options,
     };
     // TODO: Add support for JSX/TSX parsing

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -47,6 +47,35 @@ describe('Parser', () => {
       expect(ast.body[0].declarations[0].id.name).toBe('message');
     });
 
+    it('should parse code with shebang', () => {
+      const parser = new Parser();
+      const codeWithShebang = `#!/usr/bin/env node
+const x = 1;
+console.log(x);`;
+      const ast = parser.parse(codeWithShebang);
+
+      expect(ast).toBeDefined();
+      expect(ast.type).toBe('Program');
+      expect(ast.body).toHaveLength(2);
+      expect(ast.body[0].type).toBe('VariableDeclaration');
+    });
+
+    it('should parse code with different shebang formats', () => {
+      const parser = new Parser();
+      const testCases = [
+        '#!/usr/bin/node\nconst x = 1;',
+        '#!/usr/local/bin/node\nconst x = 1;',
+        '#!/usr/bin/env node\nconst x = 1;',
+      ];
+
+      testCases.forEach((code) => {
+        const ast = parser.parse(code);
+        expect(ast).toBeDefined();
+        expect(ast.type).toBe('Program');
+        expect(ast.body[0].type).toBe('VariableDeclaration');
+      });
+    });
+
     it('should parse function declaration', () => {
       const parser = new Parser();
       const code = 'function greet(name) { return "Hello " + name; }';


### PR DESCRIPTION
## Summary
- Enable parsing of JavaScript files with shebang (`#\!/usr/bin/env node`)
- Fix parsing errors when processing Node.js executable scripts
- Add comprehensive test coverage for various shebang formats

## Problem
Node.js executable scripts often include a shebang at the beginning of the file. The current parser configuration would throw an error when encountering these files, preventing the tool from processing valid Node.js scripts.

## Solution
Set `allowHashBang: true` by default in the Parser constructor. This leverages Acorn's built-in shebang handling capability, maintaining proper line/column tracking without additional complexity.

## Test Plan
- [x] Added unit tests for files with shebang
- [x] Added tests for various shebang formats
- [x] Verified backward compatibility with existing tests
- [x] All quality checks pass (typecheck, lint, format)
- [x] Build succeeds

## Performance Impact
- **Computation**: O(1) - configuration change only
- **Memory**: No additional memory usage
- **Runtime**: No performance impact

## Security Considerations
- Shebang is only parsed, not executed
- No injection vulnerabilities introduced
- Input validation handled by Acorn

🤖 Generated with [Claude Code](https://claude.ai/code)