### PR TITLE
fix: handle @babel/generator CommonJS/ESM dual package compatibility

### DIFF
--- a/src/generator/adapters/babel-adapter.ts
+++ b/src/generator/adapters/babel-adapter.ts
@@ -1,5 +1,8 @@
-import generate from '@babel/generator';
+import babelGenerate from '@babel/generator';
 import type { CodeGenerator, GeneratorOptions } from '../types.js';
+
+// Handle both CommonJS and ESM imports
+const generate = (babelGenerate as any).default || babelGenerate;
 
 /**
  * Adapter for @babel/generator


### PR DESCRIPTION
## Summary
- Fix @babel/generator import to handle both CommonJS and ESM formats
- Resolves 'generate is not a function' error when running the CLI

## Problem
The @babel/generator package exports both CommonJS and ESM formats. When imported in an ESM context, the actual generator function may be nested under a `.default` property, causing the error:
```
TypeError: generate is not a function
```

## Solution
Added compatibility handling to check for both import formats:
```typescript
const generate = (babelGenerate as any).default || babelGenerate;
```

This ensures the generator works correctly in both CommonJS and ESM environments.

## Test Results
- ✅ All tests pass (130 passed, 7 skipped)
- ✅ CLI successfully processes ES2022+ syntax
- ✅ Build successful

## Example
The fix has been verified with ES2022+ syntax features:
```javascript
// Input with optional chaining and nullish coalescing
const test = async () => {
  const data = await fetch(url?.path ?? "/api");
  return data?.json?.() ?? {};
};
```

Correctly generates formatted output without errors.