### PR TITLE
feat: add SequenceExpression support for comma operator

### DIFF
--- a/src/generator/converter/ast-converter.ts
+++ b/src/generator/converter/ast-converter.ts
@@ -93,6 +93,8 @@ export class ASTConverter {
         return t.awaitExpression(this.convert(node.argument));
       case 'YieldExpression':
         return t.yieldExpression(node.argument ? this.convert(node.argument) : null, node.delegate);
+      case 'SequenceExpression':
+        return this.convertSequenceExpression(node);
 
       default:
         console.warn(`Unsupported node type: ${node.type}`);
@@ -507,5 +509,10 @@ export class ASTConverter {
   private convertArrayPattern(node: any): t.ArrayPattern {
     const elements = node.elements.map((el: any) => (el ? this.convertPattern(el) : null));
     return t.arrayPattern(elements);
+  }
+
+  private convertSequenceExpression(node: any): t.SequenceExpression {
+    const expressions = node.expressions.map((expr: any) => this.convert(expr));
+    return t.sequenceExpression(expressions);
   }
 }

--- a/tests/unit/generator/sequence-expression.test.ts
+++ b/tests/unit/generator/sequence-expression.test.ts
@@ -1,0 +1,52 @@
+import * as acorn from 'acorn';
+import { describe, expect, it } from 'vitest';
+import { HybridGenerator } from '../../../src/generator/hybrid-generator.js';
+
+describe('SequenceExpression support', () => {
+  const generator = new HybridGenerator();
+
+  it('should generate code for simple sequence expression', () => {
+    const code = 'let result = (a = 1, b = 2, a + b);';
+    const ast = acorn.parse(code, { ecmaVersion: 2022 });
+    const generated = generator.generate(ast);
+
+    // Should include the sequence expression
+    expect(generated).toContain('a = 1');
+    expect(generated).toContain('b = 2');
+    expect(generated).toContain('a + b');
+  });
+
+  it('should handle sequence expression in for loop', () => {
+    const code = 'for (let i = 0, j = 10; i < j; i++, j--) { console.log(i, j); }';
+    const ast = acorn.parse(code, { ecmaVersion: 2022 });
+    const generated = generator.generate(ast);
+
+    expect(generated).toContain('for');
+    expect(generated).toContain('i = 0');
+    expect(generated).toContain('j = 10');
+    expect(generated).toContain('i++');
+    expect(generated).toContain('j--');
+  });
+
+  it('should handle nested sequence expressions', () => {
+    const code = 'let x = (a = 1, (b = 2, c = 3), a + b + c);';
+    const ast = acorn.parse(code, { ecmaVersion: 2022 });
+    const generated = generator.generate(ast);
+
+    expect(generated).toContain('a = 1');
+    expect(generated).toContain('b = 2');
+    expect(generated).toContain('c = 3');
+    expect(generated).toContain('a + b + c');
+  });
+
+  it('should handle sequence expression with function calls', () => {
+    const code = 'let result = (console.log("first"), console.log("second"), 42);';
+    const ast = acorn.parse(code, { ecmaVersion: 2022 });
+    const generated = generator.generate(ast);
+
+    expect(generated).toContain('console.log');
+    expect(generated).toMatch(/['"]first['"]/);
+    expect(generated).toMatch(/['"]second['"]/);
+    expect(generated).toContain('42');
+  });
+});


### PR DESCRIPTION
## Summary
- Add support for JavaScript SequenceExpression (comma operator)
- Resolves warning: "Unsupported node type: SequenceExpression"

## Problem
When processing JavaScript files containing sequence expressions (comma operator), the tool would display a warning and skip code generation for these nodes:
```
Unsupported node type: SequenceExpression
```

This is commonly found in:
- Minified code
- For loop multiple variable initialization/updates
- Compact code patterns like `(a = 1, b = 2, a + b)`

## Solution
Added proper handling for SequenceExpression in the AST converter:
- New `convertSequenceExpression` method that maps expressions array
- Integration with existing switch statement in convert method
- Full support via @babel/generator

## Test Coverage
Added comprehensive test cases covering:
- Simple sequence expressions
- Sequence expressions in for loops  
- Nested sequence expressions
- Sequence expressions with function calls

All tests pass: ✅ 134 passed

## Example
```javascript
// Input
const x = (1, 2, 3);

// Output (correctly formatted)
const x = (1, 2, 3);
```