### PR TITLE
feat: add explicit support for ForInStatement and ForOfStatement

### DIFF
--- a/src/generator/converter/ast-converter.ts
+++ b/src/generator/converter/ast-converter.ts
@@ -32,6 +32,10 @@ export class ASTConverter {
         return this.convertBlockStatement(node);
       case 'ForStatement':
         return this.convertForStatement(node);
+      case 'ForInStatement':
+        return this.convertForInStatement(node);
+      case 'ForOfStatement':
+        return this.convertForOfStatement(node);
       case 'WhileStatement':
         return this.convertWhileStatement(node);
       case 'DoWhileStatement':
@@ -225,6 +229,26 @@ export class ASTConverter {
     const update = node.update ? this.convert(node.update) : null;
     const body = this.convert(node.body);
     return t.forStatement(init, test, update, body);
+  }
+
+  private convertForInStatement(node: any): t.ForInStatement {
+    const left =
+      node.left.type === 'VariableDeclaration'
+        ? this.convert(node.left)
+        : this.convertPattern(node.left);
+    const right = this.convert(node.right);
+    const body = this.convert(node.body);
+    return t.forInStatement(left, right, body);
+  }
+
+  private convertForOfStatement(node: any): t.ForOfStatement {
+    const left =
+      node.left.type === 'VariableDeclaration'
+        ? this.convert(node.left)
+        : this.convertPattern(node.left);
+    const right = this.convert(node.right);
+    const body = this.convert(node.body);
+    return t.forOfStatement(left, right, body, node.await || false);
   }
 
   private convertWhileStatement(node: any): t.WhileStatement {

--- a/tests/unit/generator/for-in-of-statements.test.ts
+++ b/tests/unit/generator/for-in-of-statements.test.ts
@@ -1,0 +1,100 @@
+import * as acorn from 'acorn';
+import { describe, expect, it } from 'vitest';
+import { HybridGenerator } from '../../../src/generator/hybrid-generator.js';
+
+describe('ForIn and ForOf statements support', () => {
+  const generator = new HybridGenerator();
+
+  describe('ForOfStatement', () => {
+    it('should generate code for simple for-of loop', () => {
+      const code = 'for (const item of items) { console.log(item); }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('for');
+      expect(generated).toContain('const item of items');
+      expect(generated).toContain('console.log(item)');
+    });
+
+    it('should handle for-of with array destructuring', () => {
+      const code = 'for (const [key, value] of entries) { console.log(key, value); }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('for');
+      expect(generated).toContain('[key, value] of entries');
+      expect(generated).toContain('console.log(key, value)');
+    });
+
+    it('should handle for-await-of loop', () => {
+      const code =
+        'async function test() { for await (const item of asyncItems) { console.log(item); } }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('async function');
+      expect(generated).toContain('for await');
+      expect(generated).toContain('const item of asyncItems');
+    });
+
+    it('should handle for-of with let declaration', () => {
+      const code = 'for (let x of array) { x = x * 2; }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('for');
+      expect(generated).toContain('let x of array');
+      expect(generated).toContain('x = x * 2');
+    });
+  });
+
+  describe('ForInStatement', () => {
+    it('should generate code for simple for-in loop', () => {
+      const code = 'for (const key in object) { console.log(key); }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('for');
+      expect(generated).toContain('const key in object');
+      expect(generated).toContain('console.log(key)');
+    });
+
+    it('should handle for-in with var declaration', () => {
+      const code = 'for (var prop in obj) { result[prop] = obj[prop]; }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('for');
+      expect(generated).toContain('var prop in obj');
+      expect(generated).toContain('result[prop] = obj[prop]');
+    });
+
+    it('should handle for-in without declaration', () => {
+      const code = 'let i; for (i in items) { process(i); }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('let i');
+      expect(generated).toContain('for');
+      expect(generated).toContain('i in items');
+      expect(generated).toContain('process(i)');
+    });
+
+    it('should handle nested for-in and for-of loops', () => {
+      const code = `
+        for (const key in obj) {
+          for (const item of obj[key]) {
+            console.log(key, item);
+          }
+        }
+      `;
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('for');
+      expect(generated).toContain('const key in obj');
+      expect(generated).toContain('const item of obj[key]');
+      expect(generated).toContain('console.log(key, item)');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add explicit support for JavaScript for-in and for-of loops
- Resolves warning: "Unsupported node type: ForOfStatement"

## Problem
When processing JavaScript files containing for-of loops, the tool would display a warning:
```
Unsupported node type: ForOfStatement
```

While the code was still generated (through escodegen fallback), this warning was misleading and the explicit support ensures better compatibility with modern JavaScript syntax.

## Solution
Added dedicated conversion methods in the AST converter:
- `convertForInStatement` for for-in loops
- `convertForOfStatement` for for-of loops (including for-await-of)
- Proper handling of both variable declarations and patterns in loop heads
- Support for async iteration with for-await-of

## Test Coverage
Added comprehensive test suite covering:
- Simple for-of loops
- Array destructuring in for-of
- For-await-of async iteration
- Simple for-in loops  
- Various declaration types (const, let, var)
- Nested for-in and for-of loops

All tests pass: ✅ 142 passed

## Example
```javascript
// Input
for (const item of items) {
  console.log(item);
}

// Output (correctly formatted)
for (const item of items) {
  console.log(item);
}
```

No more warnings for for-of/for-in statements!