### PR TITLE
feat: add support for missing JavaScript node types

### DIFF
--- a/src/generator/converter/ast-converter.ts
+++ b/src/generator/converter/ast-converter.ts
@@ -99,6 +99,16 @@ export class ASTConverter {
         return t.yieldExpression(node.argument ? this.convert(node.argument) : null, node.delegate);
       case 'SequenceExpression':
         return this.convertSequenceExpression(node);
+      case 'ImportExpression':
+        return this.convertImportExpression(node);
+      case 'Super':
+        return t.super();
+      case 'MetaProperty':
+        return this.convertMetaProperty(node);
+      case 'ClassExpression':
+        return this.convertClassExpression(node);
+      case 'EmptyStatement':
+        return t.emptyStatement();
 
       default:
         console.warn(`Unsupported node type: ${node.type}`);
@@ -538,5 +548,21 @@ export class ASTConverter {
   private convertSequenceExpression(node: any): t.SequenceExpression {
     const expressions = node.expressions.map((expr: any) => this.convert(expr));
     return t.sequenceExpression(expressions);
+  }
+
+  private convertImportExpression(node: any): t.Import | t.CallExpression {
+    // @babel/types doesn't have a direct import() expression, use callExpression with import
+    return t.callExpression(t.import(), [this.convert(node.source)]);
+  }
+
+  private convertMetaProperty(node: any): t.MetaProperty {
+    return t.metaProperty(t.identifier(node.meta.name), t.identifier(node.property.name));
+  }
+
+  private convertClassExpression(node: any): t.ClassExpression {
+    const id = node.id ? t.identifier(node.id.name) : null;
+    const superClass = node.superClass ? this.convert(node.superClass) : null;
+    const body = this.convertClassBody(node.body);
+    return t.classExpression(id, superClass, body);
   }
 }

--- a/tests/unit/generator/missing-node-types.test.ts
+++ b/tests/unit/generator/missing-node-types.test.ts
@@ -1,0 +1,155 @@
+import * as acorn from 'acorn';
+import { describe, expect, it } from 'vitest';
+import { HybridGenerator } from '../../../src/generator/hybrid-generator.js';
+
+describe('Missing node types support', () => {
+  const generator = new HybridGenerator();
+
+  describe('ImportExpression', () => {
+    it('should generate code for dynamic import', () => {
+      const code = 'const module = import("./module.js");';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('import');
+      expect(generated).toMatch(/['"]\.\/module\.js['"]/);
+    });
+
+    it('should handle dynamic import in async function', () => {
+      const code = 'async function load() { const mod = await import("./lib.js"); }';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('async function');
+      expect(generated).toContain('await import');
+      expect(generated).toMatch(/['"]\.\/lib\.js['"]/);
+    });
+  });
+
+  describe('Super', () => {
+    it('should generate code for super in constructor', () => {
+      const code = `
+        class Child extends Parent {
+          constructor() {
+            super();
+          }
+        }
+      `;
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('class Child extends Parent');
+      expect(generated).toContain('super()');
+    });
+
+    it('should handle super method calls', () => {
+      const code = `
+        class Child extends Parent {
+          method() {
+            super.method();
+          }
+        }
+      `;
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('super.method()');
+    });
+
+    it('should handle super property access', () => {
+      const code = `
+        class Child extends Parent {
+          get prop() {
+            return super.prop;
+          }
+        }
+      `;
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('super.prop');
+    });
+  });
+
+  describe('MetaProperty', () => {
+    it('should generate code for import.meta', () => {
+      const code = 'const url = import.meta.url;';
+      const ast = acorn.parse(code, { ecmaVersion: 2022, sourceType: 'module' });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('import.meta.url');
+    });
+
+    it('should handle new.target', () => {
+      const code = `
+        function Constructor() {
+          if (new.target === Constructor) {
+            console.log("called with new");
+          }
+        }
+      `;
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('new.target');
+    });
+  });
+
+  describe('ClassExpression', () => {
+    it('should generate code for anonymous class expression', () => {
+      const code = 'const MyClass = class { constructor() {} };';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('class');
+      expect(generated).toContain('constructor()');
+    });
+
+    it('should handle named class expression', () => {
+      const code = 'const MyClass = class NamedClass { method() {} };';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('class NamedClass');
+      expect(generated).toContain('method()');
+    });
+
+    it('should handle class expression with extends', () => {
+      const code = 'const Child = class extends Parent { constructor() { super(); } };';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('class extends Parent');
+      expect(generated).toContain('super()');
+    });
+  });
+
+  describe('EmptyStatement', () => {
+    it('should handle empty statement', () => {
+      const code = 'if (true) ;';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('if');
+      expect(generated).toContain('true');
+    });
+
+    it('should handle empty statement in loop', () => {
+      const code = 'for (let i = 0; i < 10; i++) ;';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('for');
+      expect(generated).toContain('i < 10');
+    });
+
+    it('should handle standalone semicolon', () => {
+      const code = 'let x = 1;;let y = 2;';
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      const generated = generator.generate(ast);
+
+      expect(generated).toContain('let x = 1');
+      expect(generated).toContain('let y = 2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add explicit support for 5 JavaScript AST node types
- Eliminates "Unsupported node type" warnings for modern JavaScript constructs

## Problem
When processing JavaScript files with certain language features, the tool would display warnings:
```
Unsupported node type: ImportExpression
Unsupported node type: Super
Unsupported node type: MetaProperty
Unsupported node type: ClassExpression
Unsupported node type: EmptyStatement
```

While code was still generated through escodegen fallback, these warnings were misleading and indicated incomplete support.

## Solution
Added dedicated conversion methods in the AST converter for each missing node type:

### Supported Node Types
1. **ImportExpression** - Dynamic imports: `import('./module.js')`
2. **Super** - Super keyword: `super()`, `super.method()`
3. **MetaProperty** - Meta properties: `import.meta.url`, `new.target`
4. **ClassExpression** - Class expressions: `const C = class { }`
5. **EmptyStatement** - Empty statements: `;` or `if (x) ;`

## Test Coverage
Comprehensive test suite with 13 test cases covering:
- Dynamic imports in various contexts
- Super calls, method calls, and property access
- import.meta and new.target usage
- Anonymous and named class expressions
- Empty statements in different contexts

All tests pass: ✅ 155 passed

## Example
```javascript
// Dynamic import - no more warnings\!
const module = import('./module.js');

// Class expression - properly formatted
const MyClass = class extends Parent {
  constructor() {
    super(); // Super support
  }
};

// Meta properties work correctly  
console.log(import.meta.url);
```

No more warnings for these common JavaScript features\!