### PR TITLE
fix: robustly handle malformed DoWhileStatement test conditions

### DIFF
--- a/tests/unit/generator/dowhile-statement-robust.test.ts
+++ b/tests/unit/generator/dowhile-statement-robust.test.ts
@@ -1,0 +1,158 @@
+import * as acorn from 'acorn';
+import { describe, expect, it } from 'vitest';
+import { HybridGenerator } from '../../../src/generator/hybrid-generator.js';
+
+describe('DoWhileStatement robust error handling', () => {
+  const generator = new HybridGenerator();
+
+  it('should handle normal do-while loop', () => {
+    const code = 'do { console.log("test"); } while (x < 10);';
+    const ast = acorn.parse(code, { ecmaVersion: 2022 });
+    const generated = generator.generate(ast);
+
+    expect(generated).toContain('do');
+    expect(generated).toContain('while');
+    expect(generated).toContain('x < 10');
+  });
+
+  it('should handle malformed AST with ExpressionStatement test', () => {
+    // Simulate malformed AST where test is an ExpressionStatement
+    const ast = {
+      type: 'Program',
+      body: [
+        {
+          type: 'DoWhileStatement',
+          body: {
+            type: 'BlockStatement',
+            body: [
+              {
+                type: 'ExpressionStatement',
+                expression: {
+                  type: 'CallExpression',
+                  callee: { type: 'Identifier', name: 'console' },
+                  arguments: [],
+                },
+              },
+            ],
+          },
+          test: {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'BinaryExpression',
+              operator: '<',
+              left: { type: 'Identifier', name: 'x' },
+              right: { type: 'Literal', value: 10, raw: '10' },
+            },
+          },
+        },
+      ],
+    };
+
+    const generated = generator.generate(ast);
+    expect(generated).toContain('do');
+    expect(generated).toContain('while');
+    expect(generated).toContain('x < 10');
+  });
+
+  it('should handle malformed AST with BlockStatement test', () => {
+    // Simulate malformed AST where test is a BlockStatement (invalid but should not crash)
+    const ast = {
+      type: 'Program',
+      body: [
+        {
+          type: 'DoWhileStatement',
+          body: {
+            type: 'BlockStatement',
+            body: [],
+          },
+          test: {
+            type: 'BlockStatement',
+            body: [
+              {
+                type: 'ExpressionStatement',
+                expression: { type: 'Literal', value: true, raw: 'true' },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    // Should fallback to true or handle gracefully
+    const generated = generator.generate(ast);
+    expect(generated).toContain('do');
+    expect(generated).toContain('while');
+  });
+
+  it('should handle malformed AST with IfStatement test', () => {
+    // Simulate malformed AST where test is an IfStatement (invalid but should not crash)
+    const ast = {
+      type: 'Program',
+      body: [
+        {
+          type: 'DoWhileStatement',
+          body: {
+            type: 'BlockStatement',
+            body: [],
+          },
+          test: {
+            type: 'IfStatement',
+            test: { type: 'Literal', value: true, raw: 'true' },
+            consequent: {
+              type: 'BlockStatement',
+              body: [],
+            },
+            alternate: null,
+          },
+        },
+      ],
+    };
+
+    // Should fallback to true or handle gracefully
+    const generated = generator.generate(ast);
+    expect(generated).toContain('do');
+    expect(generated).toContain('while');
+  });
+
+  it('should handle malformed AST with EmptyStatement test', () => {
+    // Simulate malformed AST where test is an EmptyStatement (invalid but should not crash)
+    const ast = {
+      type: 'Program',
+      body: [
+        {
+          type: 'DoWhileStatement',
+          body: {
+            type: 'BlockStatement',
+            body: [],
+          },
+          test: {
+            type: 'EmptyStatement',
+          },
+        },
+      ],
+    };
+
+    // Should fallback to true or handle gracefully
+    const generated = generator.generate(ast);
+    expect(generated).toContain('do');
+    expect(generated).toContain('while');
+  });
+
+  it('should handle do-while in class with various edge cases', () => {
+    const code = `
+      class Test {
+        method() {
+          do {
+            this.count++;
+          } while (this.count < 10);
+        }
+      }
+    `;
+    const ast = acorn.parse(code, { ecmaVersion: 2022 });
+    const generated = generator.generate(ast);
+
+    expect(generated).toContain('class Test');
+    expect(generated).toContain('do');
+    expect(generated).toContain('while');
+  });
+});


### PR DESCRIPTION
## Summary
- Comprehensive fix for DoWhileStatement conversion failures with malformed ASTs
- Handles all Statement types in test condition, not just ExpressionStatement
- Prevents crashes and provides graceful fallbacks

## Problem
When processing certain JavaScript files, multiple errors were occurring:
```
Failed to generate code for ClassDeclaration: TypeError: Property test 
of DoWhileStatement expected node to be of a type ["Expression"] but instead got "BlockStatement"

Failed to generate code for VariableDeclaration: TypeError: Property test 
of DoWhileStatement expected node to be of a type ["Expression"] but instead got "IfStatement"

Failed to generate code for ClassDeclaration: TypeError: Property test 
of DoWhileStatement expected node to be of a type ["Expression"] but instead got "EmptyStatement"
```

## Root Cause
The DoWhileStatement's test condition should always be an Expression, but malformed ASTs from buggy transformations or corrupted data were providing various Statement types instead.

## Solution
Implemented comprehensive defensive programming to handle all cases:

### Handled Statement Types:
1. **ExpressionStatement** - Extract the inner expression
2. **BlockStatement** - Try to extract first expression, fallback to `true`
3. **IfStatement** - Fallback to `true` with warning
4. **EmptyStatement** - Fallback to `true` with warning
5. **Other Statements** - Fallback to `true` with warning

### Code Changes:
```typescript
if (node.test.type === 'ExpressionStatement') {
  // Extract expression from ExpressionStatement
  test = this.convert(node.test.expression);
} else if (node.test.type === 'BlockStatement') {
  // Try to extract first expression or default to true
  if (node.test.body?.[0]?.type === 'ExpressionStatement') {
    test = this.convert(node.test.body[0].expression);
  } else {
    console.warn('DoWhileStatement has BlockStatement test, defaulting to true');
    test = t.booleanLiteral(true);
  }
} else if (/* other statement types */) {
  // Default to true to avoid crash
  console.warn(`DoWhileStatement has ${node.test.type} test, defaulting to true`);
  test = t.booleanLiteral(true);
}
```

## Benefits
- No more crashes on malformed ASTs
- Graceful degradation with warnings
- Preserves as much of the original intent as possible
- Helps identify problematic input data through console warnings

## Test Coverage
Added 6 comprehensive test cases:
- Normal do-while loops
- ExpressionStatement test condition
- BlockStatement test condition
- IfStatement test condition
- EmptyStatement test condition
- Do-while inside classes

All tests pass: ✅ 166 passed

This fix ensures the tool can process even severely malformed JavaScript ASTs without crashing.