### PR TITLE
fix: correct ruleset JSON format for GitHub API

### DIFF
--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -11,20 +11,16 @@
   },
   "rules": [
     {
-      "type": "deletion",
-      "description": "Prevent branch deletion"
+      "type": "deletion"
     },
     {
-      "type": "non_fast_forward",
-      "description": "Prevent force pushes"
+      "type": "non_fast_forward"
     },
     {
-      "type": "creation",
-      "description": "Prevent branch recreation"
+      "type": "creation"
     },
     {
-      "type": "required_linear_history",
-      "description": "Require linear history"
+      "type": "required_linear_history"
     },
     {
       "type": "pull_request",
@@ -34,29 +30,24 @@
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true
-      },
-      "description": "Require pull request before merging"
+      }
     },
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
         "required_status_checks": [
           {
-            "context": "test (20.x)",
-            "integration_id": null
+            "context": "test (20.x)"
           },
           {
-            "context": "test (22.x)",
-            "integration_id": null
+            "context": "test (22.x)"
           },
           {
-            "context": "test (24.x)",
-            "integration_id": null
+            "context": "test (24.x)"
           }
-        ]
-      },
-      "description": "Require CI status checks to pass"
+        ],
+        "strict_required_status_checks_policy": true
+      }
     }
   ],
   "bypass_actors": []


### PR DESCRIPTION
## Summary
Fix the GitHub ruleset JSON format to be compatible with the GitHub API.

## Problem
The previous ruleset file (merged in #27) had format issues that prevented it from being applied via the GitHub API:
- Error: "Invalid property /rules/5: data matches no possible input"

## Solution
Updated the ruleset JSON to match the exact API specification:
- ✅ Removed `description` fields from all rules (not supported by API)
- ✅ Removed `integration_id` fields from status checks (should be omitted, not null)
- ✅ Kept `strict_required_status_checks_policy` at the correct parameters level

## Test
The updated ruleset can now be successfully applied using:
```bash
gh api repos/castor4bit/beautichunk/rulesets \
  --method POST \
  --input .github/rulesets/protect-main.json
```

## Changes
- `.github/rulesets/protect-main.json` - Fixed API compatibility issues

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>